### PR TITLE
Add Dependency Checks in radio.sh

### DIFF
--- a/radio
+++ b/radio
@@ -29,6 +29,16 @@ fi
 
 trap "rm -f $fifo" INT TERM EXIT
 
+check_dependencies() {
+    for cmd in zenity mplayer; do
+        if ! command -v "$cmd" &> /dev/null; then
+            echo "$cmd is not installed."
+            return 1
+        fi
+    done
+    return 0
+}
+
 
 playradio() {
 auswahl=$(awk -F "	" '{print $1"\n"$2}' $pfadsender | zenity --list --hide-column=1 --column "Nummer" --column "Sender" --title="Bashtuner" --ok-label="Abspielen" --cancel-label="Exit" --text="Radiosender einschalten" --width=600 --height=300)
@@ -60,4 +70,9 @@ done
 playradio
 fi
 }
+check_dependencies
+if [ $? -ne 0 ]; then
+    echo "Please install the missing dependencies and try again."
+    exit 1
+fi
 playradio


### PR DESCRIPTION
Hi @Born2Root 

This commit introduces a new function to check for the installation of essential dependencies, specifically mplayer and zenity, before launching the radio application. If either dependency is missing, the script will display an appropriate error message and exit gracefully, improving user experience and preventing runtime errors.